### PR TITLE
chore: Add .gitignore for Go project hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Go
+bin/
+*.exe
+*.out
+*.test
+
+# Dependency directories
+vendor/
+
+# OS
+.DS_Store
+Thumbs.db
+


### PR DESCRIPTION
This PR adds a standard .gitignore file for Go projects to prevent committing binaries, build outputs, and vendor files.